### PR TITLE
Add above-gate reference rows for heat_index_rothfusz validation

### DIFF
--- a/ts_heat_index.json
+++ b/ts_heat_index.json
@@ -1,6 +1,6 @@
 {
   "information": {
-    "summary": "This file contains a series of validation tables for the heat_index() function in pythermalcomfort, jsthermalcomfort.",
+    "summary": "This file contains a series of validation tables for the heat_index() function in pythermalcomfort, jsthermalcomfort. Heat-index rows validate the Rothfusz formula; consumers should disable input limiting (limit_inputs=False) when running these cases.",
     "version": "1.0.0",
     "license": "MIT"
   },
@@ -24,6 +24,60 @@
       },
       "outputs": {
         "hi": 37.7
+      }
+    },
+    {
+      "inputs": {
+        "tdb": 27,
+        "rh": 30
+      },
+      "outputs": {
+        "hi": 26.4
+      }
+    },
+    {
+      "inputs": {
+        "tdb": 28,
+        "rh": 50
+      },
+      "outputs": {
+        "hi": 28.4
+      }
+    },
+    {
+      "inputs": {
+        "tdb": 32,
+        "rh": 60
+      },
+      "outputs": {
+        "hi": 37.1
+      }
+    },
+    {
+      "inputs": {
+        "tdb": 35,
+        "rh": 80
+      },
+      "outputs": {
+        "hi": 56.5
+      }
+    },
+    {
+      "inputs": {
+        "tdb": 40,
+        "rh": 40
+      },
+      "outputs": {
+        "hi": 48.3
+      }
+    },
+    {
+      "inputs": {
+        "tdb": 45,
+        "rh": 25
+      },
+      "outputs": {
+        "hi": 50.5
       }
     }
   ]


### PR DESCRIPTION
## What this PR does

- Adds six `tdb >= 27` reference rows to `ts_heat_index.json`, verified against `pythermalcomfort 3.9.3 heat_index_rothfusz(limit_inputs=False)`.
- Appends one sentence to `information.summary` noting that consumers should disable input limiting when running these cases.

## Why this change is needed

- pythermalcomfort 3.9.3 `heat_index_rothfusz` gates `tdb < 27 °C` to NaN by default (`limit_inputs=True`). The current fixture only has two rows; one of them (`tdb=25`) sits below the gate. Above-gate coverage is needed to validate the Rothfusz formula across the operational range.
- Coverage spans low/mid/high `rh` and the "no risk" through "extreme danger" stress bands.
- Supports the parallel `jsthermalcomfort` work on issue [FedericoTartarini/jsthermalcomfort#142](https://github.com/FedericoTartarini/jsthermalcomfort/issues/142).

## How I tested it

- [x] `python check_json_files.py` reports `ts_heat_index.json` correct
- [x] All eight rows match `heat_index_rothfusz(**inputs, limit_inputs=False).hi` within the stored 0.1 tolerance against pythermalcomfort 3.9.3

## Notes for reviewers

- Existing two rows are unchanged.
- No version bump on `information.version` (most `ts_*.json` files stay at `1.0.0` across edits; happy to bump to `1.1.0` if you prefer that convention).
- pythermalcomfort harness (`tests/test_heat_index_rothfusz.py`) already calls `heat_index_rothfusz(**inputs, limit_inputs=False)`, so existing Python validation continues to work without harness changes. jsthermalcomfort's harness will adopt the same override in a follow-up PR.