### PR TITLE
Add validation table for wind_chill_temperature

### DIFF
--- a/ts_wind_chill_temperature.json
+++ b/ts_wind_chill_temperature.json
@@ -1,0 +1,94 @@
+{
+  "information": {
+    "summary": "Validation tables for wind_chill_temperature() in pythermalcomfort and jsthermalcomfort. Reference values match pythermalcomfort 3.9.3.",
+    "version": "1.0.0",
+    "license": "MIT"
+  },
+  "tolerance": {
+    "wct": 0.1
+  },
+  "data": [
+    {
+      "inputs": {
+        "tdb": -40,
+        "v": 30
+      },
+      "outputs": {
+        "wct": -58.7
+      }
+    },
+    {
+      "inputs": {
+        "tdb": -20,
+        "v": 5
+      },
+      "outputs": {
+        "wct": -24.3
+      }
+    },
+    {
+      "inputs": {
+        "tdb": -20,
+        "v": 15
+      },
+      "outputs": {
+        "wct": -29.1
+      }
+    },
+    {
+      "inputs": {
+        "tdb": -20,
+        "v": 60
+      },
+      "outputs": {
+        "wct": -36.5
+      }
+    },
+    {
+      "inputs": {
+        "tdb": -10,
+        "v": 10
+      },
+      "outputs": {
+        "wct": -15.3
+      }
+    },
+    {
+      "inputs": {
+        "tdb": -5,
+        "v": 5.5
+      },
+      "outputs": {
+        "wct": -7.5
+      }
+    },
+    {
+      "inputs": {
+        "tdb": -5,
+        "v": 5.5,
+        "round_output": false
+      },
+      "outputs": {
+        "wct": -7.527
+      }
+    },
+    {
+      "inputs": {
+        "tdb": 0,
+        "v": 0.1
+      },
+      "outputs": {
+        "wct": 5.3
+      }
+    },
+    {
+      "inputs": {
+        "tdb": 0,
+        "v": 1.5
+      },
+      "outputs": {
+        "wct": 1.0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds `ts_wind_chill_temperature.json`, a shared validation table for
pythermalcomfort's `wind_chill_temperature()`. Values match pythermalcomfort
3.9.3. A follow-up jsthermalcomfort PR will consume this table.

Schema follows `ts_wind_chill.json`: `information` / `tolerance` / `data`,
with `round_output: true|false` as an input flag.

The table covers:
- a cold-weather range (`tdb` from -40 to 0 °C, `v` from 5 to 60 km/h)
- two low-wind boundary points (`v = 0.1` and `1.5` km/h) matching the
  existing `ts_wind_chill.json` cases
- one `round_output: false` row for the unrounded code path

No R validation is claimed for this table.